### PR TITLE
Fixed configs for LDF soldiers to use correct magazines.

### DIFF
--- a/Caliber-Conversion/MSBS-5.56B/config.cpp
+++ b/Caliber-Conversion/MSBS-5.56B/config.cpp
@@ -11,6 +11,7 @@ class CfgPatches
 		{
 			"A3_Weapons_F",
 			"A3_Weapons_F_Enoch",
+			"A3_characters_f_enoch",
 			"A3_Anims_F_Config_Sdr",
 			"A3_Data_F",
 			"A3_Ui_F",
@@ -26,6 +27,8 @@ class CfgPatches
 		weapons[] = {"s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag_TracerG","s39_30Rnd_556x45_msbs_mag_TracerR","s39_30Rnd_556x45_msbs_mag_TracerY","s39_30Rnd_556x45_msbs_mag_m995_ap","s39_30Rnd_556x45_msbs_mag_mk262","s39_30Rnd_556x45_msbs_mag_mk318","s39_30Rnd_556x45_msbs_mag_ir_dim"};
 	};
 };
+
+#include "ldfconfig.cpp"
 
 class CfgMagazines
 {

--- a/Caliber-Conversion/MSBS-5.56B/ldfconfig.cpp
+++ b/Caliber-Conversion/MSBS-5.56B/ldfconfig.cpp
@@ -1,0 +1,284 @@
+class cfgVehicles 
+{	
+	class I_E_Man_Base_F;
+	class I_E_Soldier_base_F : I_E_Man_Base_F {};
+	class I_E_Soldier_F: I_E_Soldier_base_F
+	{
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+	};
+
+	class I_E_Soldier_A_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_AAR_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Support_AMG_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Support_AMort_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_AAA_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_AAT_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_CBRN_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Medic_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Crew_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Engineer_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_Exp_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_GL_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Support_GMG_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Support_MG_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Support_Mort_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_soldier_M_F : I_E_Soldier_base_F {
+
+		magazines[] = { "20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_MP_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_Exp_F : I_E_Soldier_base_F {};
+	class I_E_soldier_Mine_F : I_E_Soldier_Exp_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_AA_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_AT_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Officer_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_Pathfinder_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_RadioOperator_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_Repair_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_LAT_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_LAT2_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_lite_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_SL_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_TL_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_Soldier_UAV_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_soldier_UAV_06_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_soldier_UAV_06_medical_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_soldier_UGV_02_Demining_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+
+	class I_E_soldier_UGV_02_Science_F : I_E_Soldier_base_F {
+
+		magazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+		respawnMagazines[] = { "s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","s39_30Rnd_556x45_msbs_mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","11Rnd_45ACP_Mag","HandGrenade","SmokeShell","SmokeShellBlue","Chemlight_Blue","Chemlight_Blue" };
+
+	};
+};


### PR DESCRIPTION
Previously LDF soldiers from _Contact_ DLC were not able to fight if spawned/placed in editor with additional modification. 
Added ldfconfig.cpp to the MSBS folder and included it in the config.cpp for the gun near the top of the file.
Tested as working with our modpack on a locally signed build
Binarization of files while packing pbos doesn't seem to matter.