### PR TITLE
FF Modules Secondary Objectives

### DIFF
--- a/FirefightModules/config.cpp
+++ b/FirefightModules/config.cpp
@@ -41,6 +41,7 @@ class cfgFunctions {
       class createPatrol {};
       class garrisonNearBuilding {};
       class initFirefight {};
+      class secondaryObjectives {};
     };
 
     class guiFunctions {

--- a/FirefightModules/functions/firefightModuleFunctions/fn_allowMove.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_allowMove.sqf
@@ -1,3 +1,19 @@
+/*
+ * Utility function added to a unit that re-enables AI pathing.
+ * Intended for use with the firefight modules, specifically the 'garrisonBuilding'
+ * function.
+ *
+ * Params:
+ * A trigger logic object.
+ *
+ * Returns:
+ * Nothing.
+ *
+ * Exampe:
+ * [myUnitTrigger] call s39_fnc_allowMove
+ *
+*/
+
 _syncedTrigger = _this select 0;
 _groups = [];
 _allUnits = [];

--- a/FirefightModules/functions/firefightModuleFunctions/fn_clearFirefight.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_clearFirefight.sqf
@@ -1,3 +1,18 @@
+/*
+ * Utility function created to clear firefights and objectives spawned by
+ * the firefight module system.
+ *
+ * Params:
+ * None.
+ *
+ * Returns:
+ * Nothing.
+ *
+ * Exampe:
+ * [] call s39_fnc_clearFirefight.
+ *
+*/
+
 //Check if our task exists and bail if it doesn't.
 _taskExists = ["ffAreaObj"] call BIS_fnc_taskExists;
 

--- a/FirefightModules/functions/firefightModuleFunctions/fn_clearFirefight.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_clearFirefight.sqf
@@ -13,6 +13,13 @@ _radius = 300;
 
 } forEach nearestObjects [_location, ["all"], _radius];
 
-//Delete our task.
-["ffAreaObj"] call BIS_fnc_deleteTask;
+//Delete our tasks that exist.
+
+{
+  _taskExists = [_x] call BIS_fnc_taskExists;
+  if(_taskExists) then {
+    [_x] call BIS_fnc_deleteTask;
+  };
+} forEach ["foundIntelComplete", "smallCacheDestroyed", "bigCacheDestroyed", "fuelDropDestroyed", "disabledCommsComplete", "secureBlackboxComplete", "ffAreaObj"];
+
 _handle = [] spawn {hint "Skirmish cleared!"; sleep 3; hintSilent "";};

--- a/FirefightModules/functions/firefightModuleFunctions/fn_createPatrol.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_createPatrol.sqf
@@ -1,4 +1,16 @@
-
+/* Create a patrol..
+ * Can be used on its own or in conjunection with other functions.
+ *
+ * Params:
+ * 0 - _faction - Name of the facion you want soldiers from
+ * 1 - _pos - position to spawn/garrison the soldiers near.
+ * 2 - _soldierConfigs - array - array of available entries to spawn soldiers from.
+ * returns - BOOL - true if success, false if failed.
+ *
+ * Exampe:
+ * ["IND_F", 0,0,0, _soldierConfigs] call s39_fnc_createPatrol;
+ *
+*/
 
 //Parameters
 _faction = param [0,"",[""]];

--- a/FirefightModules/functions/firefightModuleFunctions/fn_garrisonNearBuilding.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_garrisonNearBuilding.sqf
@@ -5,8 +5,8 @@
  * Params:
  * 0 - _faction - Name of the facion you want soldiers from
  * 1 - _pos - position to spawn/garrison the soldiers near.
- *
- *
+ * 2 - _allowMove - bool - whether or not to add a trigger which allows the garrison to leave the building.
+ * 3 - _soldierConfigs - array - array of available entries to spawn soldiers from. 
  * returns - BOOL - true if success, false if failed.
  *
  * Exampe:

--- a/FirefightModules/functions/firefightModuleFunctions/fn_initFirefight.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_initFirefight.sqf
@@ -140,6 +140,10 @@ _allowMove = selectRandom [true,false];
 
 } forEach _patrolPositions;
 
+//Setup our secondary objectives, we'll do two for now.
+[_firefightLoc, _radius] call s39_fnc_secondaryObjectives;
+
+[_firefightLoc, _radius] call s39_fnc_secondaryObjectives;
 //Create our task. Sanity checking to remove/readd the task if it was previously created/completed.
 if (_taskExists) then {
   ["ffAreaObj"] call BIS_fnc_deleteTask;

--- a/FirefightModules/functions/firefightModuleFunctions/fn_initFirefight.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_initFirefight.sqf
@@ -1,14 +1,14 @@
 /*
  * Garrisons buildings near a given map marker with infantry units of the
  * specified faction. Also spawns up to 5 patrolling groups of the same faction.
- * Garrisoned units will leave their garrison if BLUFOR gets within 25m of the
+ * Some garrisoned units will leave their garrison if BLUFOR gets within 25m of the
  * leader of the group. Group max size is 8 for garrisons, 4 for patrols.
  *
  * Random garrisoned units will be able to leave their positions if BLUFOR is
  * within 25 meters.
  *
  * Params:
- * _firefightMarker - string - marker name.
+ * _firefightMarker - string - Marker position.
  * _faction - string - facion name from CfgFactions
  * _radius [optional] - integer - Radius to fill buildings in. 150 is default.
  * _level [optional] - string - how heavy the garrison should be. Defaults to full

--- a/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
@@ -113,7 +113,7 @@ switch (_type) do {
     	"_caller distance _target < 3",						// Condition for the action to progress
     	{},													// Code executed when action starts
     	{},													// Code executed on every progress tick
-    	{ [true, "foundIntelComplete", ["","Found Intel",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{ [true, ["foundIntelComplete", "ffAreaObj"], ["","Found Intel",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
     	{},													// Code executed on interrupted
     	[],													// Arguments passed to the scripts as _this select 3
     	10,													// Action duration [s]
@@ -129,7 +129,7 @@ switch (_type) do {
 		smallCacheBox setVariable ["ace_cookoff_enableammocookoff", false, true];
 		smallAmmoBox1 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		smallAmmoBox2 setVariable ["ace_cookoff_enableammocookoff", false, true];
-		smallCacheBox addMPEventHandler ["MPKilled", {[true, "smallCacheDestroyed", ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+		smallCacheBox addMPEventHandler ["MPKilled", {[true, ["smallCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
 
 	};
 
@@ -138,13 +138,13 @@ switch (_type) do {
 		bigCacheTgt setVariable ["ace_cookoff_enableammocookoff", false, true];
 		bigCacheAmmo1 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		bigCacheAmmo2 setVariable ["ace_cookoff_enableammocookoff", false, true];
-		bigCacheTgt addMPEventHandler ["MPKilled", {[true, "bigCacheDestroyed", ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+		bigCacheTgt addMPEventHandler ["MPKilled", {[true, ["bigCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
 
 	};
 
   case "fuelDrop" : {
 
-		fuelDropTgt addMPEventHandler ["MPKilled", {[true, "fuelDropDestroyed", ["","Destroyed fuel cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+		fuelDropTgt addMPEventHandler ["MPKilled", {[true, ["fuelDropDestroyed", "ffAreaObj"], ["","Destroyed fuel cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
 
 	};
 
@@ -159,7 +159,7 @@ switch (_type) do {
     	"_caller distance _target < 3",						// Condition for the action to progress
     	{},													// Code executed when action starts
     	{},													// Code executed on every progress tick
-    	{ [true, "disabledCommsComplete", ["","Disabled Comms",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{ [true, ["disabledCommsComplete", "ffAreaObj"], ["","Disabled Comms",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
     	{},													// Code executed on interrupted
     	[],													// Arguments passed to the scripts as _this select 3
     	10,													// Action duration [s]
@@ -181,7 +181,7 @@ switch (_type) do {
     	"_caller distance _target < 3",						// Condition for the action to progress
     	{},													// Code executed when action starts
     	{},													// Code executed on every progress tick
-    	{ [true, "secureBlackboxComplete", ["","Secured Black Box",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{ [true, ["secureBlackboxComplete", "ffAreaObj"], ["","Secured Black Box",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
     	{},													// Code executed on interrupted
     	[],													// Arguments passed to the scripts as _this select 3
     	12,													// Action duration [s]

--- a/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
@@ -1,0 +1,201 @@
+/*
+
+Generates some secondary objectives to be inserted into the firefights.
+Params:
+
+ 0 - Array - Center of FF location, or manually set.
+ 1 - Integer - Radius we'll be searching for positions to spawn objectives in.
+
+*/
+
+_ffLocation = param [0, [0,0,0], [[]]];
+_radius = param [1, 0, [0]];
+
+//Now some objective location definitions.
+_evidenceTable = [[
+	["Land_RattanTable_01_F",[0.20752,-0.708008,0],150.215,1,0,[0,-0],"","",true,false],
+	["Land_Money_F",[0.358887,-0.421875,0.813],198.726,1,0,[0,0],"money2","",true,false],
+	["Land_Money_F",[0.216309,-0.582031,0.813],0,1,0,[0,0],"money1","",true,false],
+	["Land_MobilePhone_smart_F",[0.0200195,-0.77832,0.813],134.305,1,0,[0,-0],"opforCom","",true,false],
+	["Land_Money_F",[0.48877,-0.748047,0.813],333.435,1,0,[0,0],"money3","",true,false],
+	["Land_Map_F",[-0.0102539,-0.993164,0.813],84.579,1,0,[0,0],"opforMap","",true,false]
+], "evidenceTable", "B_Quadbike_01_F"];
+
+_smallCache = [[
+	["rhs_weapon_crate",[0.0341797,-1.10791,0],177.599,1,0,[],"smallCacheBox","",true,false],
+	["rhs_mags_crate",[0.86377,0.774414,0],246.66,1,0,[],"smallAmmoBox1","",true,false],
+	["rhs_mags_crate",[-0.199707,1.43164,0],0,1,0,[],"smallAmmoBox2","",true,false],
+	["Land_BagFence_Round_F",[1.34082,1.58887,-0.00130129],225,1,0,[],"","",true,false],
+	["Land_BagFence_Round_F",[-1.38232,1.6665,-0.00130129],135,1,0,[],"","",true,false],
+	["Land_BagFence_Round_F",[1.29834,-2.05371,-0.00130129],315,1,0,[],"","",true,false],
+	["Land_BagFence_Round_F",[-1.42432,-1.97607,-0.00130129],45,1,0,[],"","",true,false]
+], "smallCache", "B_MRAP_01_F"];
+
+_bigCache = [[
+	["Box_IND_Ammo_F",[1.05078,0.507324,0],95.9177,1,0,[0,-0],"bigCacheAmmo1","",true,false],
+	["Land_EmergencyBlanket_01_stack_F",[-0.716309,-1.10645,0],26.2363,1,0,[0,0],"","",true,false],
+	["Land_FirstAidKit_01_closed_F",[-0.768555,-1.09326,0.255],318.711,1,0,[0,0],"","",true,false],
+	["Box_FIA_Wps_F",[0.526367,-0.720703,0],318.009,1,0,[0,0],"bigCacheTgt","",true,false],
+	["Land_Sleeping_bag_folded_F",[-0.478516,-1.62695,0],318.009,1,0,[0,0],"","",true,false],
+	["Box_IND_Grenades_F",[1.75439,0.137695,0],194.732,1,0,[0,0],"bigCacheAmmo2","",true,false],
+	["Land_WaterBottle_01_pack_F",[1.46191,-1.09668,0],318.009,1,0,[0,0],"","",true,false],
+	["Land_WaterBottle_01_pack_F",[1.47998,-1.36279,0],74.3657,1,0,[0,0],"","",true,false],
+	["Land_FoodSacks_01_small_brown_F",[1.95459,-0.668945,0],72.8206,1,0,[0,0],"","",true,false]
+], "bigCache", "B_MRAP_01_F"];
+
+//safe size B_Plane_CAS_01_dynamicLoadout_F
+_fuelDrop = [[
+	["Land_Tank_rust_F",[1.42529,-0.492188,0],89.319,1,0,[0,0],"fuelDropTgt","",true,false],
+	["Land_MetalBarrel_F",[1.62939,3.0376,0],101.105,1,0,[0,-0],"","",true,false],
+	["B_G_Van_01_fuel_F",[-2.71094,1.43262,0.127322],226.807,1,0,[0,0],"fuelDropTruck","",true,false],
+	["Land_MetalBarrel_F",[2.63477,3.10205,0],116.111,1,0,[0,-0],"","",true,false],
+	["Land_MetalBarrel_F",[3.31055,2.4917,0],206.1,1,0,[0,0],"","",true,false],
+	["Land_PaperBox_closed_F",[4.11426,0.890625,0],344.319,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_empty_F",[1.30127,4.06445,0],326.115,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_empty_F",[0.544922,4.37451,0],206.115,1,0,[0,0],"","",true,false],
+	["Land_Pallet_F",[4.31641,-1.34912,0],14.3192,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_F",[4.92725,-0.234375,0],299.315,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_F",[2.62598,4.21924,0],206.1,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_empty_F",[1.37939,4.94043,0],146.115,1,0,[0,-0],"","",true,false],
+	["Land_CanisterFuel_F",[3.51807,3.78369,0],146.114,1,0,[0,-0],"","",true,false],
+	["Land_CanisterFuel_F",[3.62451,4.28711,0],206.137,1,0,[0,0],"","",true,false],
+	["Land_MetalBarrel_F",[5.67822,-0.206543,0],14.3242,1,0,[0,0],"","",true,false]
+], "fuelDrop", "B_Plane_CAS_01_dynamicLoadout_F"];
+
+_dataRelay = [[
+	["Land_PortableGenerator_01_F",[1.56152,0.649902,0],165.637,1,0,[0,-0],"dataRelayTgt_1","",true,false],
+	["Land_CampingChair_V1_F",[1.53662,-0.746094,0],254.929,1,0,[0,0],"","",true,false],
+	["Land_BagFence_Round_F",[1.50439,-1.64258,-0.00130129],0,1,0,[0,0],"","",true,false],
+	["Land_CampingTable_small_F",[2.01367,-0.535645,0],239.935,1,0,[0,0],"","",true,false],
+	["Land_BagFence_Round_F",[1.64551,1.66895,-0.00130129],179.65,1,0,[0,-0],"","",true,false],
+	["Land_Laptop_unfolded_F",[1.94873,-0.621094,0.813],245.895,1,0,[0,0],"dataRelayTgt_2","",true,false],
+	["Land_BagFence_Long_F",[-2.34229,-0.238281,-0.000999928],268.901,1,0,[0,0],"","",true,false],
+	["Land_SatelliteAntenna_01_F",[2.20117,0.278809,0],60.0055,1,0,[0,0],"dataRelayTgt_3","",true,false],
+	["Land_BagFence_Long_F",[-1.36084,2.24414,-0.000999928],314,1,0,[0,0],"","",true,false],
+	["Land_BagFence_Long_F",[-1.22021,-2.58936,-0.000999928],39.655,1,0,[0,0],"","",true,false],
+	["Land_BagFence_Round_F",[3.29639,-0.0849609,-0.00130129],270.265,1,0,[0,0],"","",true,false]
+], "dataRelay", "B_MRAP_01_F"];
+
+_heliCrashSite = [[
+	["Land_ShellCrater_01_F",[0.146973,-1.85693,0],0,1,0,[0,0],"","",true,false],
+	["CraterLong_02_F",[0.982422,-4.49561,-0.0401669],150,1,0,[0,-0],"","",true,false],
+	["Land_ShellCrater_02_decal_F",[-2.78662,1.91992,0],0,1,0,[0,0],"","",true,false],
+	["Land_ShellCrater_02_decal_F",[3.70361,1.66992,0],90,1,0,[0,-0],"","",true,false],
+	["CraterLong_02_small_F",[-1.21533,6.04932,0],0,1,0,[0,0],"","",true,false],
+	["Land_Wreck_Heli_02_Wreck_01_F",[-0.428711,-4.11182,-0.517661],330,1,0,[0,0],"heliCrashTgt","",true,false],
+	["Land_ShellCrater_02_decal_F",[-3.05469,-4.82129,0],270,1,0,[0,0],"","",true,false],
+	["Land_ShellCrater_02_decal_F",[3.43506,-5.07129,0],180,1,0,[0,0],"","",true,false],
+	["Land_Wreck_Heli_02_Wreck_02_F",[-1.73828,5.02637,-0.540195],0,1,0,[0,0],"","",true,false],
+	["Land_Wreck_Heli_02_Wreck_04_F",[4.9209,-4.69922,0],60,1,0,[0,0],"","",true,false],
+	["Land_Wreck_Heli_02_Wreck_03_F",[-2.12109,-6.96973,0],270,1,0,[0,0],"","",true,false]
+], "heliCrashSite", "B_Plane_CAS_01_dynamicLoadout_F"];
+
+_possibleObjs = [_evidenceTable, _smallCache, _bigCache, _fuelDrop, _dataRelay, _heliCrashSite];
+
+_objective = selectRandom _possibleObjs;
+
+_objects = _objective select 0;
+_type = _objective select 1;
+_safeZoneArea = _objective select 2;
+
+_objSpawnLoc = [_ffLocation, 5, _radius, 3, 0, 20, 0] call BIS_fnc_findSafePos;
+[_objSpawnLoc, random 360, _objects] call BIS_fnc_ObjectsMapper;
+
+switch (_type) do {
+  case "evidenceTable" : {
+
+    [
+    	opforCom,											// Object the action is attached to
+    	"Secure Intel",										// Title of the action
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_search_ca.paa",	// Idle icon shown on screen
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_search_ca.paa",	// Progress icon shown on screen
+    	"_this distance _target < 3",						// Condition for the action to be shown
+    	"_caller distance _target < 3",						// Condition for the action to progress
+    	{},													// Code executed when action starts
+    	{},													// Code executed on every progress tick
+    	{ [true, "foundIntelComplete", ["","Found Intel",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{},													// Code executed on interrupted
+    	[],													// Arguments passed to the scripts as _this select 3
+    	10,													// Action duration [s]
+    	0,													// Priority
+    	true,												// Remove on completion
+    	false												// Show in unconscious state
+    ] remoteExec ["BIS_fnc_holdActionAdd", 0, opforCom];
+
+  };
+
+  case "smallCache" : {
+
+		smallCacheBox setVariable ["ace_cookoff_enableammocookoff", false, true];
+		smallAmmoBox1 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		smallAmmoBox2 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		smallCacheBox addMPEventHandler ["MPKilled", {[true, "smallCacheDestroyed", ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+
+	};
+
+  case "bigCache" : {
+
+		bigCacheTgt setVariable ["ace_cookoff_enableammocookoff", false, true];
+		bigCacheAmmo1 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		bigCacheAmmo2 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		bigCacheTgt addMPEventHandler ["MPKilled", {[true, "bigCacheDestroyed", ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+
+	};
+
+  case "fuelDrop" : {
+
+		fuelDropTgt addMPEventHandler ["MPKilled", {[true, "fuelDropDestroyed", ["","Destroyed fuel cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
+
+	};
+
+  case "dataRelay" : {
+
+    [
+    	dataRelayTgt_2,											// Object the action is attached to
+    	"Disable Comms",										// Title of the action
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_hack_ca.paa",	// Idle icon shown on screen
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_hack_ca.paa",	// Progress icon shown on screen
+    	"_this distance _target < 3",						// Condition for the action to be shown
+    	"_caller distance _target < 3",						// Condition for the action to progress
+    	{},													// Code executed when action starts
+    	{},													// Code executed on every progress tick
+    	{ [true, "disabledCommsComplete", ["","Disabled Comms",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{},													// Code executed on interrupted
+    	[],													// Arguments passed to the scripts as _this select 3
+    	10,													// Action duration [s]
+    	0,													// Priority
+    	true,												// Remove on completion
+    	false												// Show in unconscious state
+    ] remoteExec ["BIS_fnc_holdActionAdd", 0, dataRelayTgt_2];
+
+  };
+
+  case "heliCrashSite" : {
+
+    [
+    	heliCrashTgt,											// Object the action is attached to
+    	"Secure Black Box",										// Title of the action
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_search_ca.paa",	// Idle icon shown on screen
+    	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_search_ca.paa",	// Progress icon shown on screen
+    	"_this distance _target < 3",						// Condition for the action to be shown
+    	"_caller distance _target < 3",						// Condition for the action to progress
+    	{},													// Code executed when action starts
+    	{},													// Code executed on every progress tick
+    	{ [true, "secureBlackboxComplete", ["","Secured Black Box",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate; },				// Code executed on completion
+    	{},													// Code executed on interrupted
+    	[],													// Arguments passed to the scripts as _this select 3
+    	12,													// Action duration [s]
+    	0,													// Priority
+    	true,												// Remove on completion
+    	false												// Show in unconscious state
+    ] remoteExec ["BIS_fnc_holdActionAdd", 0, heliCrashTgt];
+
+		_smoke = createVehicle ["test_EmptyObjectForSmoke", position heliCrashTgt, [],0,"CAN_COLLIDE"];
+
+  };
+
+  default {
+    false;
+  };
+
+};

--- a/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
@@ -122,6 +122,8 @@ switch (_type) do {
     	false												// Show in unconscious state
     ] remoteExec ["BIS_fnc_holdActionAdd", 0, opforCom];
 
+		{ _x addCuratorEditableObjects [[opforCom],false];} forEach allCurators;
+
   };
 
   case "smallCache" : {
@@ -130,7 +132,7 @@ switch (_type) do {
 		smallAmmoBox1 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		smallAmmoBox2 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		smallCacheBox addMPEventHandler ["MPKilled", {[true, ["smallCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
-
+		{ _x addCuratorEditableObjects [[smallCacheBox, smallAmmoBox1, smallAmmoBox2],false];} forEach allCurators;
 	};
 
   case "bigCache" : {
@@ -139,13 +141,13 @@ switch (_type) do {
 		bigCacheAmmo1 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		bigCacheAmmo2 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		bigCacheTgt addMPEventHandler ["MPKilled", {[true, ["bigCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
-
+		{ _x addCuratorEditableObjects [[bigCacheTgt, bigCacheAmmo1, bigCacheAmmo2],false];} forEach allCurators;
 	};
 
   case "fuelDrop" : {
 
 		fuelDropTgt addMPEventHandler ["MPKilled", {[true, ["fuelDropDestroyed", "ffAreaObj"], ["","Destroyed fuel cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
-
+		{ _x addCuratorEditableObjects [[fuelDropTgt],false];} forEach allCurators;
 	};
 
   case "dataRelay" : {
@@ -167,6 +169,7 @@ switch (_type) do {
     	true,												// Remove on completion
     	false												// Show in unconscious state
     ] remoteExec ["BIS_fnc_holdActionAdd", 0, dataRelayTgt_2];
+		{ _x addCuratorEditableObjects [[dataRelayTgt_2],false];} forEach allCurators;
 
   };
 
@@ -191,6 +194,8 @@ switch (_type) do {
     ] remoteExec ["BIS_fnc_holdActionAdd", 0, heliCrashTgt];
 
 		_smoke = createVehicle ["test_EmptyObjectForSmoke", position heliCrashTgt, [],0,"CAN_COLLIDE"];
+
+		{ _x addCuratorEditableObjects [[heliCrashTgt],false];} forEach allCurators;
 
   };
 

--- a/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
+++ b/FirefightModules/functions/firefightModuleFunctions/fn_secondaryObjectives.sqf
@@ -129,7 +129,7 @@ switch (_type) do {
   case "smallCache" : {
 
 		smallCacheBox setVariable ["ace_cookoff_enableammocookoff", false, true];
-		smallAmmoBox1 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		smallAmmoBox1 setVariable ["ace_cookoff_enableammocookoff", true, true];
 		smallAmmoBox2 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		smallCacheBox addMPEventHandler ["MPKilled", {[true, ["smallCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
 		{ _x addCuratorEditableObjects [[smallCacheBox, smallAmmoBox1, smallAmmoBox2],false];} forEach allCurators;
@@ -138,7 +138,7 @@ switch (_type) do {
   case "bigCache" : {
 
 		bigCacheTgt setVariable ["ace_cookoff_enableammocookoff", false, true];
-		bigCacheAmmo1 setVariable ["ace_cookoff_enableammocookoff", false, true];
+		bigCacheAmmo1 setVariable ["ace_cookoff_enableammocookoff", true, true];
 		bigCacheAmmo2 setVariable ["ace_cookoff_enableammocookoff", false, true];
 		bigCacheTgt addMPEventHandler ["MPKilled", {[true, ["bigCacheDestroyed", "ffAreaObj"], ["","Destroyed Cache",""], objNull, "SUCCEEDED"] call BIS_fnc_taskCreate;}];
 		{ _x addCuratorEditableObjects [[bigCacheTgt, bigCacheAmmo1, bigCacheAmmo2],false];} forEach allCurators;
@@ -193,7 +193,7 @@ switch (_type) do {
     	false												// Show in unconscious state
     ] remoteExec ["BIS_fnc_holdActionAdd", 0, heliCrashTgt];
 
-		_smoke = createVehicle ["test_EmptyObjectForSmoke", position heliCrashTgt, [],0,"CAN_COLLIDE"];
+		["test_EmptyObjectForSmoke", (position heliCrashTgt), [],0,"CAN_COLLIDE"] remoteExec ["createVehicle", 0, true];
 
 		{ _x addCuratorEditableObjects [[heliCrashTgt],false];} forEach allCurators;
 


### PR DESCRIPTION
Added secondary objectives to the firefight module functions. Currently spawns two unmarked, random secondaries, Zeus can see the targets though if needed.

Possible objectives:
Evidence table - table with stacks of cash and a phone to 'hack'
Fuel depot - small collection of fuel canisters, a large fuel tank, and a fuel truck. Blow up the fuel tank.
Small cache - small ammo cache. Blow it up.
Large cache - larger cache. Blow it up.
Comms post - field SATCOM post. 'Hack' the laptop.
Heli crash site - Crashed helicopter. Recover the black box.